### PR TITLE
Revert "actualizo changelog"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,9 +42,6 @@
 - [fix/rc-14-correcion-changelod] Fix - RC-14: Se corrigió título changelod.md.
   PR: [#110](https://github.com/hmarc953/cineglobal/pull/110) - @abartomioli (Coordinador/DevOps)
 
-- [fix/rc-17-correcion-changelod] Fix - RC-17: Se arregla en base al figma el proyecto.
-  PR: [#113](https://github.com/hmarc953/cineglobal/pull/113) - @abartomioli (Coordinador/DevOps)
-
 ## [Release Primer Parcial] - 2026-04-22
 
 ### Added


### PR DESCRIPTION
Revierto este PR porque incorpora solo el último ajuste pendiente, pero no el resto de los cambios originales de rc-17. Se va a unificar todo en un único PR para evitar dejar cambios parciales en release/primer-parcial.