### PR TITLE
fix / rc19 - Eliminación de etiquetas por no ser parte del contrato de diseño inic…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,9 @@
 - [fix/rc-18-ajustes-bootstrap] Fix - RC-18: Sincronización con Figma, eliminación de componentes inventados (modal) e implementación de navegación real según auditoría de componentes.
   PR: [#120](https://github.com/hmarc953/cineglobal/pull/120) - @abartomioli (Coordinador/DevOps)
 
+- [fix/rc-19-correcion-spec] Fix - RC-19: Eliminación de etiquetas `<details>`, `<summary>` e `<iframe>` por no ser parte del contrato de diseño inicial, priorizando la fidelidad al mockup.
+  PR: [#121](https://github.com/hmarc953/cineglobal/pull/121) - @abartomioli (Coordinador/DevOps)
+
 ## [Release Primer Parcial] - 2026-04-22
 
 ### Added

--- a/docs/03-specs/primer-parcial/spec-html-avanzados.md
+++ b/docs/03-specs/primer-parcial/spec-html-avanzados.md
@@ -93,3 +93,11 @@ Guardar capturas en: docs/04-testing/capturas/tc-9/momento-2/
 -  No se detectan scrolls horizontales ni overflow visual
 -  El comportamiento general del layout es consistente en todos los dispositivos
 -  La navegación se adapta correctamente sin romper estructura visual
+
+---
+
+**Aclaración de Auditoría de Componentes Avanzados (RC-19):**
+
+**Estado:** Se eliminaron las etiquetas `<details>`, `<summary>` e `<iframe>` por no ser parte del contrato de diseño inicial.
+
+**Justificación:** Se prioriza la fidelidad al mockup entregado por el Coordinador para asegurar la consistencia del producto.


### PR DESCRIPTION
# 🟣 PULL REQUEST – Actividad Obligatoria N.º 3 – Programación Web I

---

## 📌 Datos del Estudiante

- **Nombre y Apellido:** Alejandro Bartomioli
- **Número de Matrícula:** 153041
- **Carrera:** Tecnicatura Universitaria en Programación de Sistemas  
- **Materia:** Programación Web I  
- **Profesor:** Lic. Matías Velasquez  
- **Cuatrimestre/Año:** 1º Cuatrimestre / 2026  
- **Rol asignado para esta entrega:** Coordinador/DevOps


---

## 📂 Rama de trabajo

- **Nombre de la rama:** `fix/rc-19-correcion-spec`

---

## 📝 Descripción del trabajo realizado

Eliminación de etiquetas `<details>`, `<summary>` e `<iframe>` por no ser parte del contrato de diseño inicial, priorizando la fidelidad al mockup, con otros fix, y acomodado del archivo spec-html-avanzados.md.

---

## 📄 Archivos modificados / agregados

-`changelog.md`
-`docs/03-specs/primer-parcial/spec-html-avanzados.md`