### PR TITLE
Fix RC7: Remover prompt alert testing doc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,9 @@
 - [fix/RC9-bloque-catch-vacio] Fix RC9: Bloque catch vacio
   PR: [#189](https://github.com/hmarc953/cineglobal/pull/189) @hmarc953 (Coordinador / DevOps)
 
+- [fix/RC8-checklist-incompleto] Fix RC8: Checklist incompleto 
+  PR: [#190](https://github.com/hmarc953/cineglobal/pull/190) @hmarc953 (Coordinador / DevOps)
+
 ## [Release Actividad Obligatoria N°3] - 2026-05-07
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -59,6 +59,9 @@
 - [fix/RC8-checklist-incompleto] Fix RC8: Checklist incompleto 
   PR: [#190](https://github.com/hmarc953/cineglobal/pull/190) @hmarc953 (Coordinador / DevOps)
 
+- [fix/RC7-remover-prompt-alert-testing-doc] Fix RC7: Remover prompt alert testing doc  
+  PR: [#191](https://github.com/hmarc953/cineglobal/pull/191) @hmarc953 (Coordinador / DevOps)
+
 ## [Release Actividad Obligatoria N°3] - 2026-05-07
 
 ### Added

--- a/js/test/testing-doc.md
+++ b/js/test/testing-doc.md
@@ -583,7 +583,6 @@ describe('Test de alert', () => {
 - No se contemplan escenarios de concurrencia o múltiples usuarios simultáneos.
 - La persistencia se valida mediante simulación de `localStorage` y `sessionStorage`, sin almacenamiento persistente real.
 - No se prueban aspectos visuales de la interfaz (CSS, diseño responsive o accesibilidad).
-- Las interacciones basadas en `prompt()` y `alert()` requerirían mocks o spies adicionales para una validación completa.
 
 ---
 


### PR DESCRIPTION
# 🟣 PULL REQUEST – Parcial N.º 2 – Programación Web I

---

## 📌 Datos del Estudiante

- **Nombre y Apellido:** Marc Holste
- **Número de Matrícula:** 160313
- **Carrera:** Tecnicatura Universitaria en Programación de Sistemas  
- **Materia:** Programación Web I  
- **Profesor:** Lic. Matías Velasquez  
- **Cuatrimestre/Año:** 1º Cuatrimestre / 2026  
- **Rol asignado para esta entrega:** Coordinador/DevOps

---

## 📂 Rama de trabajo

- **Nombre de la rama:** `fix/RC7-remover-prompt-alert-testing-doc`

---

## 📝 Descripción del trabajo realizado

- Se elimino la mencion del `promt()` y `alert()` en el `testing-doc.md`

---

## 📄 Archivos modificados / agregados
 
- `js/test/testing-doc.md`
- `changelog.md`