### PR TITLE
[FIX][Accessibility] Corregir contraste de colores

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@
 
 ### Fixed
 
+- [fix/209-contraste-accesibilidad] Corregir contraste de colores
+  PR: [#209](https://github.com/hmarc953/cineglobal/pull/209) @hmarc953 (Coordinador / DevOps)
+
 ## [Release Actividad Obligatoria N°4] - 2026-05-18
 
 ### Added

--- a/css/bootstrap-overrides.css
+++ b/css/bootstrap-overrides.css
@@ -96,14 +96,27 @@ body {
    5. Tablas (.table)
    Se adapta el fondo, borde y color de texto para modo oscuro.
 ================================================== */
-.table {
+.table,
+.table.table-dark {
   --bs-table-bg: var(--color-card);
   --bs-table-color: var(--color-text-main);
   --bs-table-border-color: var(--bs-border-color);
+  --bs-table-striped-bg: #282828;
+  --bs-table-striped-color: var(--color-text-main);
 
   background-color: var(--color-card) !important;
   color: var(--color-text-main) !important;
   border-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+.table > :not(caption) > * > * {
+  background-color: var(--color-card) !important;
+  color: var(--color-text-main) !important;
+}
+
+.table caption {
+  background-color: var(--color-bg-main);
+  color: var(--color-text-secondary);
 }
 
 .table thead th {
@@ -118,6 +131,7 @@ body {
 .table-striped > tbody > tr:nth-of-type(odd) {
   --bs-table-accent-bg: #282828;
   background-color: #282828 !important;
+  color: var(--color-text-main) !important;
 }
 
 /* ==================================================

--- a/css/components.css
+++ b/css/components.css
@@ -86,6 +86,12 @@ details > *:not(.details-summary) {
   border-collapse: collapse;
   width: 100%;
   margin: var(--spacing-md) 0;
+  background: var(--color-card);
+  color: var(--color-text-main);
+}
+.tabla-cartelera caption {
+  background: var(--color-bg-main);
+  color: var(--color-text-secondary);
 }
 .tabla-cartelera th,
 .tabla-cartelera td {
@@ -417,6 +423,7 @@ details > *:not(.details-summary) {
    ========================= */
 .info-box {
     background-color: #2a2a2a; 
+    color: var(--color-text-secondary);
     border-radius: 12px;       
     padding: var(--spacing-lg); 
     /* Reducimos el margen para que las cajas estén más juntas */
@@ -467,21 +474,27 @@ details > *:not(.details-summary) {
 }
 
 .contacto-texto {
-  color: var(--color-text-main);
+  color: var(--color-text-secondary);
   font-size: 0.95rem;
   line-height: 1.5;
 }
 
 .info-box .contacto-link {
-  color: #ff4d57 !important;
+  display: inline-block;
+  background-color: var(--color-accent);
+  color: var(--color-text-main) !important;
   font-weight: 700;
-  text-decoration: underline;
+  text-decoration: none;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
   margin-left: 0.5rem;
 }
 
 .info-box .contacto-link:hover,
 .info-box .contacto-link:focus {
-  color: #ff6b73 !important;
+  background-color: var(--color-accent-hover);
+  color: var(--color-text-main) !important;
+  text-decoration: underline;
 }
 
 /* =========================

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -182,6 +182,9 @@ footer {
     display: block;
     text-align: center;
     margin-bottom: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    background-color: var(--color-bg-main);
+    color: var(--color-text-secondary);
     white-space: normal;
   }
 


### PR DESCRIPTION
# 🟣 PULL REQUEST – Parcial N.º 2 – Programación Web I

---

## 📌 Datos del Estudiante

- **Nombre y Apellido:** Marc Holste
- **Número de Matrícula:** 160313
- **Carrera:** Tecnicatura Universitaria en Programación de Sistemas  
- **Materia:** Programación Web I  
- **Profesor:** Lic. Matías Velasquez  
- **Cuatrimestre/Año:** 1º Cuatrimestre / 2026  
- **Rol asignado para esta entrega:** Coordinador/DevOps

---

## 📂 Rama de trabajo

- **Nombre de la rama:** `fix/209-contraste-accesibilidad`

---

## 📝 Descripción del trabajo realizado

## Resumen

Se ajustan estilos CSS para corregir contrastes insuficientes detectados por Lighthouse en la auditoría de accesibilidad.

## Cambios realizados

- Se mejoró el contraste en tablas y captions.
- Se ajustó el contraste del bloque de contacto.
- Se corrigió la legibilidad del enlace de contacto.
- Se validó el comportamiento visual en mobile y desktop.

<img width="1850" height="741" alt="image" src="https://github.com/user-attachments/assets/f1a22e6d-0568-484e-b066-e5f1450bf309" />


---

## Issue relacionada
- Closes #209    

---

## 📄 Archivos modificados / agregados
 
- `css/bootstrap-overrides.css`
- `css/components.css`
- `css/responsive.css`
- `changelog.md`